### PR TITLE
Update benchmark automation

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,6 @@ __Notes:__
 - If your file with endpoints not in this directory then you can specify it with `--endpoints_file=<path to your endpoints.json>`
 - Script uses tmux sessions to run different endpoints in parallel. By default it uses 4 sessions but you can specify this number manually: `--limit_sessions=<number of sessions>`
 - Also you can specify the number of samples to use in benchmark with `--limit_samples=<number of samples>`
-- TriviaQA benchmark always uses not more than 10% of all samples due to its big original size
 - Path to logs and artifacts can be specified with `--write_out_base_path=<your path>`
 - If you don't want to fill spreadsheet then just remove `--write_table`. Summary artifacts will be generated anyway.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,44 @@
+# Running lm-evaluation-harness with OctoAI Endpoints
+
+You can simply run *gsm8k*, *truthfulqa_gen* or *triviaqa* and get results as artifacts `<task_name>_summary.csv` or fill corresponding Google Spreadsheet
+
+## How to run
+
+0) At the first launch:  
+    0.1) Create Google Cloud project and enable Google API. Configure OAuth and get credentials. [[Guide](https://developers.google.com/sheets/api/quickstart/python#enable_the_api)]  
+    0.2) Place `credentials.json` in `~/.config/gspread` so `gspread` will be able to automatically detect it  
+    0.3) `pip install libtmux pandas gspread gspread_dataframe gspread_formatting`  
+1) `export OCTOAI_TOKEN_PROD=...`  and (or) `export OCTOAI_TOKEN_DEV=...`  
+2) `python scripts/run_endpoints.py --endpoint_type=all --write_table`  (better run from root of repo)  
+
+__Notes:__  
+
+- At the first launch, you will need to log in to your Google account through an automatically opening browser  
+- `--endpoint_type` is one of `['prod', 'dev', 'all']`  
+- use `--task=<task name>` to run particular task  
+- Order of evaluation is following: first we go through increasing number of fewshots (0, 5, 8) and then for each of them we go over tasks  
+- If your file with endpoints not in this directory then you can specify it with `--endpoints_file=<path to your endpoints.json>`
+- Script uses tmux sessions to run different endpoints in parallel. By default it uses 4 sessions but you can specify this number manually: `--limit_sessions=<number of sessions>`
+- Also you can specify the number of samples to use in benchmark with `--limit_samples=<number of samples>`
+- TriviaQA benchmark always uses not more than 10% of all samples due to its big original size
+- Path to logs and artifacts can be specified with `--write_out_base_path=<your path>`
+- If you don't want to fill spreadsheet then just remove `--write_table`. Summary artifacts will be generated anyway.
+
+## Logs and artifacts
+
+By default all logs are saved in `lm-evaluation-harness/logs`. Example of generated logs:
+
+```
+├──logs
+   └──results_per_task                       # directory with summary files
+      └──gsm8k_summary.csv
+   └──gsm8k                                  # task name
+      ├──dev_codellama-7b-instruct-fp16      # endpoint
+      └──nf0                                 # number of fewshot
+          ├──dev_codellama-7b-instruct-fp16_2023-11-29_16:00:00.0000.json
+          └──gsm8k_write_out_info.json
+      ├──dev_codellama-13b-instruct-fp16
+      └──nf0
+          ├──dev_codellama-7b-instruct-fp16_2023-11-29_16:00:00.0000.json
+          └──gsm8k_write_out_info.json
+```

--- a/scripts/endpoints.json
+++ b/scripts/endpoints.json
@@ -1,73 +1,24 @@
 {
     "dev": [
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "codellama-7b-instruct-fp16"
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "codellama-13b-instruct-fp16"
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "codellama-34b-instruct-int4"
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "codellama-34b-instruct-fp16"
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "llama-2-13b-chat-fp16"
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "llama-2-70b-chat-int4"
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "llama-2-70b-chat-fp16"      
-      },
-      {
-        "url": "https://text.customer-endpoints.nimbus.octoml.ai",
-        "model": "mistral-7b-instruct-fp16"
-      }      
-
+      "codellama-7b-instruct-fp16",
+      "codellama-13b-instruct-fp16",
+      "codellama-34b-instruct-int4",
+      "codellama-34b-instruct-fp16",
+      "llama-2-13b-chat-fp16",
+      "llama-2-70b-chat-int4",
+      "llama-2-70b-chat-fp16",  
+      "mistral-7b-instruct-fp16"
     ],
   
     "prod": [
-      {
-        "url": "https://text.octoai.run",
-        "model": "codellama-7b-instruct-fp16"
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "codellama-13b-instruct-fp16"
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "codellama-34b-instruct-int4"
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "codellama-34b-instruct-fp16"
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "llama-2-13b-chat-fp16"
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "llama-2-70b-chat-int4"
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "llama-2-70b-chat-fp16"      
-      },
-      {
-        "url": "https://text.octoai.run",
-        "model": "mistral-7b-instruct-fp16"
-      }      
+      "codellama-7b-instruct-fp16",
+      "codellama-13b-instruct-fp16",
+      "codellama-34b-instruct-int4",
+      "codellama-34b-instruct-fp16",
+      "llama-2-13b-chat-fp16",
+      "llama-2-70b-chat-int4",
+      "llama-2-70b-chat-fp16",  
+      "mistral-7b-instruct-fp16"
     ]
   }
   

--- a/scripts/fill_table.py
+++ b/scripts/fill_table.py
@@ -10,12 +10,13 @@ from utils import init_gspread_client
 
 TASKS = ["gsm8k", "truthfulqa_gen", "triviaqa"]
 TASK_CONFIG = {
-    "gsm8k": {"column_by_fewshot": {0: "B", 5: "C", 8: "D"}, "metrics": ["acc"]},
+    "gsm8k": {"start_column": {0: "B", 5: "C", 8: "D"}, "metrics": ["acc"]},
     "truthfulqa_gen": {
-        "column_by_fewshot": {0: "G"},
+        "start_column": {0: "I"},
         "metrics": ["bleurt_acc", "bleu_acc", "rouge1_acc", "rouge2_acc", "rougeL_acc"],
     },
-    "triviaqa": {"column_by_fewshot": {0: "N", 5: "O"}, "metrics": ["em"]},
+    "triviaqa": {"start_column": {0: "P", 5: "Q"}, "metrics": ["em"]},
+    "human_eval": {"start_column": {0: "T"}, "metrics": ["acc"]}
 }
 
 
@@ -46,7 +47,7 @@ def process_benchmark_results(
             if task in res_file["results"]:
                 task_name = task
                 num_fewshot = res_file["config"]["num_fewshot"]
-        start_column = TASK_CONFIG[task_name]["column_by_fewshot"][num_fewshot]
+        start_column = TASK_CONFIG[task_name]["start_column"][num_fewshot]
         current_results = {}
         for idx, metric in enumerate(TASK_CONFIG[task_name]["metrics"]):
             current_results[metric] = res_file["results"][task_name][metric]

--- a/scripts/process_logs.py
+++ b/scripts/process_logs.py
@@ -40,7 +40,7 @@ def process_benchmark_results(
         worksheet = spreadsheet.worksheet(table_name)
     path_to_results_root = write_out_base
     artifacts_dir = os.path.join(path_to_results_root, "results_per_task")
-    with open(path_to_results, "rb", encoding="utf-8") as file:
+    with open(path_to_results, 'r', encoding="utf-8") as file:
         res_file = json.load(file)
         for task in TASKS:
             if task in res_file["results"]:

--- a/scripts/run_endpoints_benchmark.py
+++ b/scripts/run_endpoints_benchmark.py
@@ -115,13 +115,13 @@ def run_benchmark(
 
 def main() -> None: # pylint: disable=missing-function-docstring
     parser = argparse.ArgumentParser()
-    parser.add_argument("--endpoints_file", required=True, type=str)
+    parser.add_argument("--endpoints_file", type=str, default=os.path.join(str(Path(__file__).parent), "endpoints.json"))
     parser.add_argument("--benchmark_repo", type=str, default=str(Path(__file__).parent.parent))
     parser.add_argument("--write_out_base", type=str, default="./logs")
     parser.add_argument("--task", type=str, default="all")  # [gsm8k, truthfulqa, triviaqa, all]
     parser.add_argument("--endpoint_type", type=str, default="dev")
     parser.add_argument("--write_table", action="store_true")
-    parser.add_argument("--limit_sessions", type=int, default=2)
+    parser.add_argument("--limit_sessions", type=int, default=4)
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
 

--- a/scripts/run_endpoints_benchmark.py
+++ b/scripts/run_endpoints_benchmark.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 from pathlib import Path
 import json
 import os
@@ -14,7 +14,13 @@ FEWSHOTS_PER_TASK = {
     "gsm8k": [0, 5, 8],
     "truthfulqa_gen": [0],
     "triviaqa": [0, 5],
+    "human_eval": [0]
 }
+
+GSM8K_SIZE = 1319
+TRUTHFULQA_GEN_SIZE = 817
+TRIVIAQA_SIZE = 17944
+HUMANEVAL_SIZE = 163
 
 
 def parse_endpoints(
@@ -34,7 +40,8 @@ def run_benchmark(
     task: str = "gsm8k",
     write_table: bool = True,
     debug: bool = False,
-    limit: int = 3,
+    limit_sessions: int = 3,
+    limit_samples: Optional[int] = None,
 ) -> None:
     tmux_server = libtmux.Server()
     os.environ["OCTOAI_API_KEY"] = os.environ.get(f"OCTOAI_TOKEN_{endpoint_type.upper()}", "")
@@ -56,7 +63,7 @@ def run_benchmark(
         print("  -------------------------------------------------------------------------------")
         print()
 
-        if num_endpoint < limit:
+        if num_endpoint < limit_sessions:
             subprocess.run(
                 f"tmux new-session -d -s {num_endpoint} ",
                 shell=True,
@@ -71,19 +78,25 @@ def run_benchmark(
             f"{endpoint_type}_{endpoint}_{str(datetime.datetime.now()).replace(' ', '_')}.json",
         )
 
-        process_logs_script = os.path.join(str(Path(__file__).parent), 'process_logs.py')
+        fill_table_script = os.path.join(str(Path(__file__).parent), 'fill_table.py')
         write_out_abs = os.path.join(work_dir, write_out_base_path)
         if write_table:
-            write_table_command = f"""  python {process_logs_script} \
+            write_table_command = f"""  python {fill_table_script} \
                                         --path_to_results={res_output} \
                                         --model_name={endpoint_type}_{endpoint} \
                                         {'--write_table' if write_table else ''} \
                                         {'--debug_table' if debug else ''} \
                                         --write_out_base={write_out_abs}"""
+        extra_args = ""
+        # Force truncating triviaqa if limit_samples is bigger than 10%
+        if limit_samples:
+            if task != "triviaqa" or limit_samples < 0.1 * TRIVIAQA_SIZE:
+                extra_args = f"--limit={limit_samples}"
+            else:
+                extra_args = "--limit=0.1"
+        extra_args = "--limit=0.1" if task == "triviaqa" else extra_args
 
-        extra_args = "--limit=0.1" if task == "triviaqa" else ""
-
-        tmux_server.sessions[num_endpoint % limit].panes[0].send_keys(
+        tmux_server.sessions[num_endpoint % limit_sessions].panes[0].send_keys(
             f"python3 {path_to_benchmark_repo}/main.py "
             f"--model=octoai "
             f"--model_args='model_name={endpoint},prod={str(endpoint_type == 'prod')}' "
@@ -98,7 +111,7 @@ def run_benchmark(
             enter=True,
         )
 
-        tmux_server.sessions[num_endpoint % limit].panes[0].send_keys(
+        tmux_server.sessions[num_endpoint % limit_sessions].panes[0].send_keys(
             write_table_command, enter=True
         )
 
@@ -117,10 +130,11 @@ def main() -> None: # pylint: disable=missing-function-docstring
     parser.add_argument("--endpoints_file", type=str, default=os.path.join(str(Path(__file__).parent), "endpoints.json"))
     parser.add_argument("--benchmark_repo", type=str, default=str(Path(__file__).parent.parent))
     parser.add_argument("--write_out_base", type=str, default="./logs")
-    parser.add_argument("--task", type=str, default="all")  # [gsm8k, truthfulqa, triviaqa, all]
+    parser.add_argument("--task", type=str, default="all")  # [gsm8k, truthfulqa_gen, triviaqa, human_eval, all]
     parser.add_argument("--endpoint_type", type=str, default="dev")
     parser.add_argument("--write_table", action="store_true")
     parser.add_argument("--limit_sessions", type=int, default=4)
+    parser.add_argument("--limit_samples", type=int, default=None)
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
 
@@ -162,9 +176,10 @@ def main() -> None: # pylint: disable=missing-function-docstring
                         num_fewshot=num_fewshot,
                         write_out_base_path=args.write_out_base,
                         task=task,
-                        limit=args.limit_sessions,
+                        limit_sessions=args.limit_sessions,
                         write_table=args.write_table,
                         debug=args.debug,
+                        limit_samples=args.limit_samples
                     )
 
 

--- a/scripts/run_endpoints_benchmark.py
+++ b/scripts/run_endpoints_benchmark.py
@@ -134,7 +134,9 @@ def main() -> None:  # pylint: disable=missing-function-docstring
         default=os.path.join(str(Path(__file__).parent), "endpoints.json"),
     )
     parser.add_argument("--benchmark_repo", type=str, default=str(Path(__file__).parent.parent))
-    parser.add_argument("--write_out_base", type=str, default=os.path.join(Path(__file__).parent.parent, "logs"))
+    parser.add_argument(
+        "--write_out_base", type=str, default=os.path.join(Path(__file__).parent.parent, "logs")
+    )
     parser.add_argument(
         "--task", type=str, default="all"
     )  # [gsm8k, truthfulqa_gen, triviaqa, human_eval, all]

--- a/scripts/run_endpoints_benchmark.py
+++ b/scripts/run_endpoints_benchmark.py
@@ -14,7 +14,7 @@ FEWSHOTS_PER_TASK = {
     "gsm8k": [0, 5, 8],
     "truthfulqa_gen": [0],
     "triviaqa": [0, 5],
-    "human_eval": [0]
+    # "human_eval": [0]
 }
 
 GSM8K_SIZE = 1319
@@ -68,7 +68,7 @@ def run_benchmark(
                 f"tmux new-session -d -s {num_endpoint} ",
                 shell=True,
                 universal_newlines=True,
-                check=False
+                check=False,
             )
 
         write_table_command = ""
@@ -78,7 +78,7 @@ def run_benchmark(
             f"{endpoint_type}_{endpoint}_{str(datetime.datetime.now()).replace(' ', '_')}.json",
         )
 
-        fill_table_script = os.path.join(str(Path(__file__).parent), 'fill_table.py')
+        fill_table_script = os.path.join(str(Path(__file__).parent), "fill_table.py")
         write_out_abs = os.path.join(work_dir, write_out_base_path)
         if write_table:
             write_table_command = f"""  python {fill_table_script} \
@@ -125,12 +125,18 @@ def run_benchmark(
     print("Done")
 
 
-def main() -> None: # pylint: disable=missing-function-docstring
+def main() -> None:  # pylint: disable=missing-function-docstring
     parser = argparse.ArgumentParser()
-    parser.add_argument("--endpoints_file", type=str, default=os.path.join(str(Path(__file__).parent), "endpoints.json"))
+    parser.add_argument(
+        "--endpoints_file",
+        type=str,
+        default=os.path.join(str(Path(__file__).parent), "endpoints.json"),
+    )
     parser.add_argument("--benchmark_repo", type=str, default=str(Path(__file__).parent.parent))
     parser.add_argument("--write_out_base", type=str, default="./logs")
-    parser.add_argument("--task", type=str, default="all")  # [gsm8k, truthfulqa_gen, triviaqa, human_eval, all]
+    parser.add_argument(
+        "--task", type=str, default="all"
+    )  # [gsm8k, truthfulqa_gen, triviaqa, human_eval, all]
     parser.add_argument("--endpoint_type", type=str, default="dev")
     parser.add_argument("--write_table", action="store_true")
     parser.add_argument("--limit_sessions", type=int, default=4)
@@ -157,12 +163,12 @@ def main() -> None: # pylint: disable=missing-function-docstring
         table_name = "debug_table" if args.debug else today
         try:
             worksheet = spreadsheet.worksheet(table_name)
-        except: # pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             worksheet = spreadsheet.worksheet("Template").duplicate(new_sheet_name=table_name)
         idx = 0
         for endpoint_type in chosen_types:
             for endpoint in endpoints[endpoint_type]:
-                worksheet.update(f"A{3 + idx}", f"{endpoint_type}_{endpoint['model']}")
+                worksheet.update(f"A{3 + idx}", f"{endpoint_type}_{endpoint}")
                 idx += 1
 
     for num_fewshot in [0, 5, 8]:
@@ -179,7 +185,7 @@ def main() -> None: # pylint: disable=missing-function-docstring
                         limit_sessions=args.limit_sessions,
                         write_table=args.write_table,
                         debug=args.debug,
-                        limit_samples=args.limit_samples
+                        limit_samples=args.limit_samples,
                     )
 
 

--- a/scripts/run_endpoints_benchmark.py
+++ b/scripts/run_endpoints_benchmark.py
@@ -88,14 +88,8 @@ def run_benchmark(
                                         {'--write_table' if write_table else ''} \
                                         {'--debug_table' if debug else ''} \
                                         --write_out_base={write_out_abs}"""
-        extra_args = ""
-        # Force truncating triviaqa if limit_samples is bigger than 10%
-        if limit_samples:
-            if task != "triviaqa" or limit_samples < 0.1 * TRIVIAQA_SIZE:
-                extra_args = f"--limit={limit_samples}"
-            else:
-                extra_args = "--limit=0.1"
-        extra_args = "--limit=0.1" if task == "triviaqa" else extra_args
+            
+        extra_args = f"--limit={limit_samples}" if limit_samples else ""
 
         tmux_server.sessions[num_endpoint % limit_sessions].panes[0].send_keys(
             f"python3 {path_to_benchmark_repo}/main.py "

--- a/scripts/run_endpoints_benchmark.py
+++ b/scripts/run_endpoints_benchmark.py
@@ -36,7 +36,7 @@ def run_benchmark(
     endpoint_type: str,
     path_to_benchmark_repo: str,
     num_fewshot: int = 0,
-    write_out_base_path: str = "./logs",
+    write_out_base_path: str = os.path.join(Path(__file__).parent.parent, "logs"),
     task: str = "gsm8k",
     write_table: bool = True,
     debug: bool = False,
@@ -47,7 +47,7 @@ def run_benchmark(
     os.environ["OCTOAI_API_KEY"] = os.environ.get(f"OCTOAI_TOKEN_{endpoint_type.upper()}", "")
     assert os.environ["OCTOAI_API_KEY"] != "", "OctoAI token is not specified"
     for num_endpoint, endpoint in enumerate(endpoints[endpoint_type]):
-        res_path = os.path.join(write_out_base_path, task, endpoint)
+        res_path = os.path.join(write_out_base_path, task, f"{endpoint_type}_{endpoint}")
         if not os.path.exists(res_path):
             os.makedirs(res_path)
         work_dir = os.getcwd()
@@ -114,8 +114,9 @@ def run_benchmark(
         tmux_server.sessions[num_endpoint % limit_sessions].panes[0].send_keys(
             write_table_command, enter=True
         )
-
-        os.chdir(work_dir)
+        tmux_server.sessions[num_endpoint % limit_sessions].panes[0].send_keys(
+            f"cd {work_dir}", enter=True
+        )
 
     while len(tmux_server.sessions) > 0:  # wait until all tmux sessions running tests are killed
         for session in tmux_server.sessions:
@@ -133,7 +134,7 @@ def main() -> None:  # pylint: disable=missing-function-docstring
         default=os.path.join(str(Path(__file__).parent), "endpoints.json"),
     )
     parser.add_argument("--benchmark_repo", type=str, default=str(Path(__file__).parent.parent))
-    parser.add_argument("--write_out_base", type=str, default="./logs")
+    parser.add_argument("--write_out_base", type=str, default=os.path.join(Path(__file__).parent.parent, "logs"))
     parser.add_argument(
         "--task", type=str, default="all"
     )  # [gsm8k, truthfulqa_gen, triviaqa, human_eval, all]


### PR DESCRIPTION
1) Added README.md for script that benchmarks endpoints on gsm8k, truthfulqa_gen and triviaqa
2) Fixed logging
3) process_logs.py -> fill_table.py
4) Added extracting previous results from table and calculating diffs
5) Added extracting paper results and calculating diffs from paper and also filling additional table with statistics for gsm8k and human_eval to draw plots
6) Added `--limit_samples` argument for testing purposes as it is used with `--limit` from lm-evaluation-harness