### PR TITLE
Add support for llama-3 chat template

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -695,7 +695,8 @@ class Task(abc.ABC):
 
         template_tags = {
             "default": ("", "\n\n"),
-            "llama": ("\n[/INST]\n", "\n</s>\n\n<s>\n[INST]\n")
+            "llama": ("\n[/INST]\n", "\n</s>\n\n<s>\n[INST]\n"),
+            "llama3": ("<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n", "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n"),
         }
         template_type = os.environ.get("CONVERSATION_TEMPLATE", "default")
 

--- a/lm_eval/models/octoai_llms.py
+++ b/lm_eval/models/octoai_llms.py
@@ -54,6 +54,7 @@ class OctoAIEndpointRunnerBase():
         "model": self.model_name,
         "stream": False,
         "max_tokens": max_tokens,
+        "stop": ["<|eot_id|>"] if os.environ.get("CONVERSATION_TEMPLATE", "default") == "llama3" else [],
         "top_p": top_p,
         "temperature": temperature,
     }


### PR DESCRIPTION
Due to new tokenizer behaviour llama-3 requires another approach on fewshot construction and also has problem with generating end-of-sentence token so there is also `|<eot_id>|` added as a stop-token for generation
Before this commit:
```
gsm8k acc (num_fewshot=8) = 0.386
```
After:
```
gsm8k acc (num_fewshot=8) = 0.7597
```