### PR TITLE
Increase default max_tokens arg

### DIFF
--- a/lm_eval/models/octoai_llms.py
+++ b/lm_eval/models/octoai_llms.py
@@ -16,7 +16,7 @@ class OctoAIEndpointRunnerBase():
     url: str=None,
     url_postfix: str = "/v1/chat/completions",
     batch_size: int=1,
-    max_tokens: int=1024,
+    max_tokens: int=2048,
     top_p: float=1.0,
     temperature: float=0.0,
     prod=True,


### PR DESCRIPTION
It's not enough tokens to generate answer for some models (especially Hermes-2 Pro Mistral), so increase the default value since it should not affect models that already successfully answer in less number of tokens