### PR TITLE
Add try catch for json deserialization

### DIFF
--- a/lm_eval/models/octoai_llms.py
+++ b/lm_eval/models/octoai_llms.py
@@ -138,6 +138,7 @@ class OctoAIEndpointRunnerBase():
             response_text = json.loads(response_text)
           except Exception as exc:
             exception = str(exc)
+            response_text = ""
             continue
           if self.response_check(response_text):
             success = True
@@ -247,6 +248,7 @@ class OctoAIEndpointRunnerLogLikelihood(OctoAIEndpointRunnerBase):
             response_text = json.loads(response_text)
           except Exception as exc:
             exception = str(exc)
+            response_text = ""
             continue
           if self.response_check(response_text):
             success = True


### PR DESCRIPTION
In case of receiving invalid JSON the error (not connection timeout error) would occur on json deserialization so I add try-catch to continue benchmark in this case. The error will be inserted instead of model response in `write_out` files